### PR TITLE
Add subcommand ability to chain packer and inductor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ like to use, for example:
 inductor windows10
 ```
 
-In the current directory you will now have an Autounattend.xml, packer.json, and
-Vagrantfile ready for Packer `packer build packer.json`.
+This will generate an Autounattend.xml, packer.json, and Vagrantfile in the
+current directory. To chain the inductor output into Packer do this:
+
+```
+packer build $(inductor windows10)
+```
+
+This will execute inductor creating all the required artifacts for Packer and
+then execute Packer using the generated templates.
 
 ## Inductor Options
 

--- a/inductor.go
+++ b/inductor.go
@@ -124,7 +124,8 @@ func newApp() *cli.App {
 		}
 
 		// read in the packer.json.tpl
-		packerJSON, err := os.Create(c.String("packer"))
+		packerJSONOutPath := c.String("packer")
+		packerJSON, err := os.Create(packerJSONOutPath)
 		if err != nil {
 			die(err)
 		}
@@ -159,6 +160,9 @@ func newApp() *cli.App {
 		if err != nil {
 			die(err)
 		}
+
+		// this allows us to do command substitution with Packer
+		fmt.Print(packerJSONOutPath)
 	}
 	return app
 }


### PR DESCRIPTION
This should make it less likely that users will inadvertently forget to run inductor before kicking of a potentially lengthy build process.
