### PR TITLE
Multi templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ out the generated Autounattend.xml.
 generated packer.json.
 - `--vagrantfile <Vagantfile>` The file path where inductor will write out the
 generated vagrantfile.
-- `--autounattendtpl <Autounattend.xml.tpl>` The file path to the input
-Autounattend text/template used to generate the Autounattend.xml.
-- `--packertpl <packer.json.tpl>` The file path to the input packer.json
-text/template used to generate packer.json.
-- `--vagrantfiletpl <Vagrantfile.tpl>` The file path to the input Vagrantfile
-text/tepmlate used to generate the box Vagrantfile.
 - `--productkey <key>` The Windows product key to be inserted into the
 Autounattend.xml
 - `--skipwindowsupdates` When specified the Windows Update step will be skipped.
@@ -94,22 +88,51 @@ instead of WinRM. WinRM will still be configured on the box for Vagrant.
 
 ## Templates
 
-All the input templates are all standard Golang text/templates. By default
-inductor will attempt to use the following template files:
+All input templates are standard Golang text/templates. By default inductor will
+attempt to use the following template files in the current working directory:
 
-- Autounattend.xml.tpl
-- packer.json.tpl
+- Autounattend.tpl
+- packer.tpl
 - Vagrantfile.tpl
 
-By convention inductor will attempt to load and combine any templates that
-start with the file name of the specified template. For example if you used the
-default Autounattend.xml.tpl file, inductor would load and combine any file
-that matched Autounattend.xml.tpl* in the same directory as the template.
-Inductor might find Autounattend.xml.tpl.disks and Autounattend.xml.tpl.oobe
-in the same directory as Autounattend.xml.tpl. Inductor would load and combine
-all three templates before rendering them.
+Inductor supports templates spread across multiple files as well as OS specific
+templates. There is a one/many to one relationship from an input template to an
+output inductor generated file. Inductor also allows you to specialize or
+override generic input templates by OS. This works for all 3 input templates.
 
-#### Template Variables
+### Template Loading Convention
+
+(Autounattend|packer|Vagrantfile).tpl
+Example: Autounattend.tpl
+
+(Autounattend|packer|Vagrantfile)-OS.tpl
+Example: Autounattend-windows10.tpl
+
+(Autounattend|packer|Vagrantfile).subsection.tpl
+Example: Autounattend.oobe.tpl
+
+(Autounattend|packer|Vagrantfile)-OS.subsection.tpl
+Example: Autounattend-windows10.oobe.tpl
+
+Anything with an operating system in the template name that matches the
+current system you're building will take precedence over the same named template
+without an OS in the file name. Any template with an OS in the name that
+doesn't match the current system you're building is ignored.
+
+Given the following files in the current directory, the bold files will be
+automatically loaded and merged together to be rendered to produce the final
+Autounattend.xml file for Windows2012r2:
+
+- Autounattend.tpl
+- packer.tpl
+- __Autounattend-windows2012r2.tpl__
+- Autounattend-windows2008.tpl
+- __Autounattend-windows2012r2.windowsPE.tpl__
+- Autounattend-windows2008.windowsPE.tpl
+- Autounattend.windowsPE.tpl
+- __Autounattend.offlineServicing.tpl__
+
+### Template Variables
 - OSName
 -	ProductKey
 - WindowsImageName
@@ -148,16 +171,19 @@ so here it is:
 
 ```json
 {
-  "windowsXX": {
+  "windows10": {
     "iso_url": "./iso/CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
     "iso_checksum_type": "sha1",
     "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
     "windows_image_name": "Windows 10 Enterprise",
     "virtualbox_guest_os_type": "Windows81_64",
-    "vmware_guest_os_type": "windows8srv-64"
+    "vmware_guest_os_type": "windows8srv-64",
+    "product_key": "FEED-ME2D"
   }
 }
 ```
+
+Except for product_key all other fields are required.
 
 By default inductor looks in the current working directory for a file named
 osregistry.json. If you name it something else or is in another directory

--- a/README.md
+++ b/README.md
@@ -92,6 +92,48 @@ Autounattend.xml
 - `--ssh` When specified Packer will use the SSH communicator with OpenSSH
 instead of WinRM. WinRM will still be configured on the box for Vagrant.
 
+## Templates
+
+All the input templates are all standard Golang text/templates. By default
+inductor will attempt to use the following template files:
+
+- Autounattend.xml.tpl
+- packer.json.tpl
+- Vagrantfile.tpl
+
+By convention inductor will attempt to load and combine any templates that
+start with the file name of the specified template. For example if you used the
+default Autounattend.xml.tpl file, inductor would load and combine any file
+that matched Autounattend.xml.tpl* in the same directory as the template.
+Inductor might find Autounattend.xml.tpl.disks and Autounattend.xml.tpl.oobe
+in the same directory as Autounattend.xml.tpl. Inductor would load and combine
+all three templates before rendering them.
+
+#### Template Variables
+- OSName
+-	ProductKey
+- WindowsImageName
+-	VirtualboxGuestOsType
+-	VmwareGuestOsType
+-	IsoURL
+-	IsoChecksumType
+-	IsoChecksum
+-	Communicator
+-	Username
+-	Password
+-	DiskSize
+-	RAM
+-	CPU
+-	Headless
+-	WindowsUpdates
+
+### Template Functions
+- Contains
+- Replace
+- ToUpper
+- ToLower
+- SafeComputerName
+
 ## OS Registry
 
 The OS registry contains predefined attributes for each OS that inductor can

--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ like to use, for example:
 inductor windows10
 ```
 
-In the current directory you will now have an Autounattend.xml, packer.json, and
-Vagrantfile ready for Packer `packer build packer.json`.
+This will generate an Autounattend.xml, packer.json, and Vagrantfile in the
+current directory. To chain the inductor output into Packer do this:
+
+```
+packer build $(inductor windows10)
+```
+
+This will execute inductor creating all the required artifacts for Packer and
+then execute Packer using the generated templates.
 
 ## Inductor Options
 

--- a/inductor.go
+++ b/inductor.go
@@ -124,7 +124,8 @@ func newApp() *cli.App {
 		}
 
 		// read in the packer.json.tpl
-		packerJSON, err := os.Create(c.String("packer"))
+		packerJSONOutPath := c.String("packer")
+		packerJSON, err := os.Create(packerJSONOutPath)
 		if err != nil {
 			die(err)
 		}
@@ -159,6 +160,9 @@ func newApp() *cli.App {
 		if err != nil {
 			die(err)
 		}
+
+		// this allows us to do command substitution with Packer
+		fmt.Print(packerJSONOutPath)
 	}
 	return app
 }

--- a/inductor.go
+++ b/inductor.go
@@ -45,21 +45,6 @@ func newApp() *cli.App {
 			Usage: "The output Vagrantfile file path",
 		},
 		cli.StringFlag{
-			Name:  "autounattendtpl, atpl",
-			Value: "Autounattend.xml.tpl",
-			Usage: "The input Autounattend.xml template file path",
-		},
-		cli.StringFlag{
-			Name:  "packertpl, ptpl",
-			Value: "packer.json.tpl",
-			Usage: "The input packer.json template file path",
-		},
-		cli.StringFlag{
-			Name:  "vagrantfiletpl, vtpl",
-			Value: "Vagrantfile.tpl",
-			Usage: "The input Vagrantfile template file path",
-		},
-		cli.StringFlag{
 			Name:  "productkey, pk",
 			Usage: "The MS Windows product key if you have one",
 		},
@@ -152,10 +137,14 @@ func newApp() *cli.App {
 		defer vagrantfileWriter.Flush()
 
 		// finally render the packer.json and Autounattend.xml
-		packerTplPath := c.String("packertpl")
-		autounattendTplPath := c.String("autounattendtpl")
-		vagrantfileTplPath := c.String("vagrantfiletpl")
-		tpl := renderer.NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantfileTplPath)
+		cwd, err := os.Getwd()
+		if err != nil {
+			die(err)
+		}
+		tpl, err := renderer.NewPackerTemplateWithOverrides(cwd, opts.OSName)
+		if err != nil {
+			die(err)
+		}
 		err = tpl.Render(opts, packerJSONWriter, autounattendXMLWriter, vagrantfileWriter)
 		if err != nil {
 			die(err)

--- a/inductor.go
+++ b/inductor.go
@@ -123,7 +123,7 @@ func newApp() *cli.App {
 			opts.Communicator = "ssh"
 		}
 
-		// read in the packer.json.tpl
+		// create output packer.json file writer
 		packerJSONOutPath := c.String("packer")
 		packerJSON, err := os.Create(packerJSONOutPath)
 		if err != nil {
@@ -133,7 +133,7 @@ func newApp() *cli.App {
 		packerJSONWriter := bufio.NewWriter(packerJSON)
 		defer packerJSONWriter.Flush()
 
-		// read in the Autounattend.xml.tpl
+		// create output Autounattend.xml file writer
 		autounattendXML, err := os.Create(c.String("autounattend"))
 		if err != nil {
 			die(err)
@@ -142,7 +142,7 @@ func newApp() *cli.App {
 		autounattendXMLWriter := bufio.NewWriter(autounattendXML)
 		defer autounattendXMLWriter.Flush()
 
-		// read in the Vagrantfile.tpl
+		// create output Vagrantfile file writer
 		vagrantfile, err := os.Create(c.String("vagrantfile"))
 		if err != nil {
 			die(err)

--- a/osregistry/operating_system_test.go
+++ b/osregistry/operating_system_test.go
@@ -1,6 +1,7 @@
 package osregistry
 
 import (
+	"sort"
 	"strings"
 	"testing"
 )
@@ -29,6 +30,7 @@ var testData = `
 func TestCanListAllOSs(t *testing.T) {
 	registry := createRegistry(t)
 	os := registry.List()
+	sort.Strings(os)
 	if len(os) != 2 {
 		t.Errorf("Expected 2 OS entries, but got %d instead", len(os))
 	} else {

--- a/renderer/packer_template.go
+++ b/renderer/packer_template.go
@@ -27,12 +27,7 @@ func NewPackerTemplateWithOverrides(baseDir string, osName string) (*PackerTempl
 }
 
 func readTemplates(baseDir string, baseFilename string, osName string) (string, error) {
-	tplFiles, err := ListFiles(baseDir, baseFilename)
-	if err != nil {
-		return "", err
-	}
-
-	tplFiles = FilterFilesToRender(tplFiles, osName)
+	tplFiles := FilterFilesToRender(ListFiles(baseDir, baseFilename), osName)
 	tpl := ""
 	for _, f := range tplFiles {
 		newTpl, err := ioutil.ReadFile(f)

--- a/renderer/packer_template.go
+++ b/renderer/packer_template.go
@@ -22,9 +22,20 @@ func NewPackerTemplateWithOverrides(packerTplPath string, autounattendTplPath st
 		fmt.Println(fmt.Sprintf("WARN: Couldn't open '%s', defaulting to internal inductor template", file))
 	}
 
-	packerTpl, err := ioutil.ReadFile(packerTplPath)
-	if err == nil {
-		tpl.PackerTpl = string(packerTpl)
+	packerTplFiles, err := filepath.Glob(packerTplPath + "*")
+	if len(packerTplFiles) > 0 {
+		for _, f := range packerTplFiles {
+			packerTpl, err := ioutil.ReadFile(f)
+			if err != nil {
+				tpl.PackerTpl = defaultTpl.PackerTpl
+				warnUsingDefault(packerTplPath)
+				break
+			}
+			if len(tpl.PackerTpl) > 0 {
+				tpl.PackerTpl = tpl.PackerTpl + "\n"
+			}
+			tpl.PackerTpl = tpl.PackerTpl + string(packerTpl)
+		}
 	} else {
 		tpl.PackerTpl = defaultTpl.PackerTpl
 		warnUsingDefault(packerTplPath)

--- a/renderer/packer_template.go
+++ b/renderer/packer_template.go
@@ -22,50 +22,41 @@ func NewPackerTemplateWithOverrides(packerTplPath string, autounattendTplPath st
 		fmt.Println(fmt.Sprintf("WARN: Couldn't open '%s', defaulting to internal inductor template", file))
 	}
 
-	packerTplFiles, err := filepath.Glob(packerTplPath + "*")
-	if len(packerTplFiles) > 0 {
-		for _, f := range packerTplFiles {
-			packerTpl, err := ioutil.ReadFile(f)
-			if err != nil {
-				tpl.PackerTpl = defaultTpl.PackerTpl
-				warnUsingDefault(packerTplPath)
-				break
-			}
-			if len(tpl.PackerTpl) > 0 {
-				tpl.PackerTpl = tpl.PackerTpl + "\n"
-			}
-			tpl.PackerTpl = tpl.PackerTpl + string(packerTpl)
-		}
-	} else {
+	tpl.PackerTpl = readTemplates(packerTplPath)
+	if tpl.PackerTpl == "" {
 		tpl.PackerTpl = defaultTpl.PackerTpl
 		warnUsingDefault(packerTplPath)
 	}
 
-	autounattendTplFiles, err := filepath.Glob(autounattendTplPath + "*")
-	if len(autounattendTplFiles) > 0 {
-		for _, f := range autounattendTplFiles {
-			autounattendTpl, err := ioutil.ReadFile(f)
-			if err != nil {
-				tpl.AutounattendTpl = defaultTpl.AutounattendTpl
-				warnUsingDefault(vagrantfileTplPath)
-				break
-			}
-			if len(tpl.AutounattendTpl) > 0 {
-				tpl.AutounattendTpl = tpl.AutounattendTpl + "\n"
-			}
-			tpl.AutounattendTpl = tpl.AutounattendTpl + string(autounattendTpl)
-		}
-	} else {
+	tpl.AutounattendTpl = readTemplates(autounattendTplPath)
+	if tpl.AutounattendTpl == "" {
 		tpl.AutounattendTpl = defaultTpl.AutounattendTpl
+		warnUsingDefault(autounattendTplPath)
+	}
+
+	tpl.VagrantfileTpl = readTemplates(vagrantfileTplPath)
+	if tpl.VagrantfileTpl == "" {
+		tpl.VagrantfileTpl = defaultTpl.VagrantfileTpl
 		warnUsingDefault(vagrantfileTplPath)
 	}
 
-	vagrantfileTpl, err := ioutil.ReadFile(vagrantfileTplPath)
-	if err == nil {
-		tpl.VagrantfileTpl = string(vagrantfileTpl)
-	} else {
-		tpl.VagrantfileTpl = defaultTpl.VagrantfileTpl
-		warnUsingDefault(vagrantfileTplPath)
+	return tpl
+}
+
+func readTemplates(tplPath string) string {
+	tpl := ""
+	tplFiles, err := filepath.Glob(tplPath + "*")
+	if err == nil && len(tplFiles) > 0 {
+		for _, f := range tplFiles {
+			newTpl, err := ioutil.ReadFile(f)
+			if err != nil {
+				return ""
+			}
+			if len(tpl) > 0 {
+				tpl = tpl + "\n"
+			}
+			tpl = tpl + string(newTpl)
+		}
 	}
 	return tpl
 }

--- a/renderer/packer_template_test.go
+++ b/renderer/packer_template_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -16,22 +17,51 @@ func TestCanLoadTemplates(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// stub out the vagrant, packer, and autounattend files
-	packerTplPath := path.Join(tmpDir, "packer.json.tpl")
-	autounattendTplPath := path.Join(tmpDir, "Autounattend.xml.tpl")
-	vagrantTplPath := path.Join(tmpDir, "Vagrantfile.tpl")
-
-	ioutil.WriteFile(packerTplPath, []byte("packer.json contents"), 0644)
-	ioutil.WriteFile(autounattendTplPath, []byte("Autounattend.xml contents"), 0644)
-	ioutil.WriteFile(vagrantTplPath, []byte("Vagrantfile contents"), 0644)
+	packerTplPath := createTemplateFile(tmpDir, "packer.json.tpl")
+	autounattendTplPath := createTemplateFile(tmpDir, "Autounattend.xml.tpl")
+	vagrantTplPath := createTemplateFile(tmpDir, "Vagrantfile.tpl")
 
 	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
-	if template.PackerTpl != "packer.json contents" {
+	if template.PackerTpl != "packer.json.tpl" {
 		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
 	}
-	if template.AutounattendTpl != "Autounattend.xml contents" {
+	if template.AutounattendTpl != "Autounattend.xml.tpl" {
 		t.Errorf("The Autounattend.xml.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
 	}
-	if template.VagrantfileTpl != "Vagrantfile contents" {
+	if template.VagrantfileTpl != "Vagrantfile.tpl" {
 		t.Errorf("The Vagrantfile.tpl wasn't properly read in, got: %s", template.VagrantfileTpl)
 	}
+}
+
+func TestCanLoadAutounattendMultiTemplates(t *testing.T) {
+	// create temporary directory to store all our testNewPackerTemplate() files
+	tmpDir, err := ioutil.TempDir("", "inductor")
+	if err != nil {
+		t.Error("Couldn't create test temp dir: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// stub out the vagrant, packer, and autounattend files
+	packerTplPath := createTemplateFile(tmpDir, "packer.json.tpl")
+	vagrantTplPath := createTemplateFile(tmpDir, "Vagrantfile.tpl")
+	autounattendTplPath := createTemplateFile(tmpDir, "Autounattend.xml.tpl")
+	createTemplateFile(tmpDir, "Autounattend.xml.tpl.disks")
+	createTemplateFile(tmpDir, "Autounattend.xml.tpl.oobe")
+
+	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
+	if !strings.Contains(template.AutounattendTpl, "Autounattend.xml.tpl") {
+		t.Errorf("The main Autounattend.xml.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
+	}
+	if !strings.Contains(template.AutounattendTpl, "Autounattend.xml.tpl.disks") {
+		t.Errorf("The Autounattend.xml.tpl.disks wasn't properly read in, got: %s", template.AutounattendTpl)
+	}
+	if !strings.Contains(template.AutounattendTpl, "Autounattend.xml.tpl.oobe") {
+		t.Errorf("The Autounattend.xml.tpl.oobe wasn't properly read in, got: %s", template.AutounattendTpl)
+	}
+}
+
+func createTemplateFile(tmpDir string, filename string) string {
+	tplPath := path.Join(tmpDir, filename)
+	ioutil.WriteFile(tplPath, []byte(filename), 0644)
+	return tplPath
 }

--- a/renderer/packer_template_test.go
+++ b/renderer/packer_template_test.go
@@ -17,16 +17,19 @@ func TestCanLoadTemplates(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// stub out the vagrant, packer, and autounattend files
-	packerTplPath := createTemplateFile(tmpDir, "packer.json.tpl")
-	autounattendTplPath := createTemplateFile(tmpDir, "Autounattend.xml.tpl")
-	vagrantTplPath := createTemplateFile(tmpDir, "Vagrantfile.tpl")
+	createTemplateFile(tmpDir, "packer.tpl")
+	createTemplateFile(tmpDir, "Autounattend.tpl")
+	createTemplateFile(tmpDir, "Vagrantfile.tpl")
 
-	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
-	if template.PackerTpl != "packer.json.tpl" {
-		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	template, err := NewPackerTemplateWithOverrides(tmpDir, "windows2012r2")
+	if err != nil {
+		t.Error("Error loading Packer templates with overrides", err)
 	}
-	if template.AutounattendTpl != "Autounattend.xml.tpl" {
-		t.Errorf("The Autounattend.xml.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
+	if template.PackerTpl != "packer.tpl" {
+		t.Errorf("The packer.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	}
+	if template.AutounattendTpl != "Autounattend.tpl" {
+		t.Errorf("The Autounattend.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
 	}
 	if template.VagrantfileTpl != "Vagrantfile.tpl" {
 		t.Errorf("The Vagrantfile.tpl wasn't properly read in, got: %s", template.VagrantfileTpl)
@@ -42,21 +45,24 @@ func TestCanLoadAutounattendMultiTemplates(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// stub out the vagrant, packer, and autounattend files
-	packerTplPath := createTemplateFile(tmpDir, "packer.json.tpl")
-	vagrantTplPath := createTemplateFile(tmpDir, "Vagrantfile.tpl")
-	autounattendTplPath := createTemplateFile(tmpDir, "Autounattend.xml.tpl")
-	createTemplateFile(tmpDir, "Autounattend.xml.tpl.disks")
-	createTemplateFile(tmpDir, "Autounattend.xml.tpl.oobe")
+	createTemplateFile(tmpDir, "packer.tpl")
+	createTemplateFile(tmpDir, "Vagrantfile.tpl")
+	createTemplateFile(tmpDir, "Autounattend.tpl")
+	createTemplateFile(tmpDir, "Autounattend-windows2012r2.windowsPE.tpl")
+	createTemplateFile(tmpDir, "Autounattend-windows2012r2.oobe.tpl")
 
-	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
-	if !strings.Contains(template.AutounattendTpl, "Autounattend.xml.tpl") {
+	template, err := NewPackerTemplateWithOverrides(tmpDir, "windows2012r2")
+	if err != nil {
+		t.Error("Error loading Packer templates with overrides", err)
+	}
+	if !strings.Contains(template.AutounattendTpl, "Autounattend.tpl") {
 		t.Errorf("The main Autounattend.xml.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
 	}
-	if !strings.Contains(template.AutounattendTpl, "Autounattend.xml.tpl.disks") {
-		t.Errorf("The Autounattend.xml.tpl.disks wasn't properly read in, got: %s", template.AutounattendTpl)
+	if !strings.Contains(template.AutounattendTpl, "Autounattend-windows2012r2.windowsPE.tpl") {
+		t.Errorf("The Autounattend-windows2012r2.windowsPE.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
 	}
-	if !strings.Contains(template.AutounattendTpl, "Autounattend.xml.tpl.oobe") {
-		t.Errorf("The Autounattend.xml.tpl.oobe wasn't properly read in, got: %s", template.AutounattendTpl)
+	if !strings.Contains(template.AutounattendTpl, "Autounattend-windows2012r2.oobe.tpl") {
+		t.Errorf("The Autounattend-windows2012r2.oobe.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
 	}
 }
 
@@ -69,21 +75,24 @@ func TestCanLoadPackerJSONMultiTemplates(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// stub out the vagrant, packer, and autounattend files
-	vagrantTplPath := createTemplateFile(tmpDir, "Vagrantfile.tpl")
-	autounattendTplPath := createTemplateFile(tmpDir, "Autounattend.xml.tpl")
-	packerTplPath := createTemplateFile(tmpDir, "packer.json.tpl")
-	createTemplateFile(tmpDir, "packer.json.tpl.vbox")
-	createTemplateFile(tmpDir, "packer.json.tpl.vmware")
+	createTemplateFile(tmpDir, "Vagrantfile.tpl")
+	createTemplateFile(tmpDir, "Autounattend.tpl")
+	createTemplateFile(tmpDir, "packer.tpl")
+	createTemplateFile(tmpDir, "packer.vbox.tpl")
+	createTemplateFile(tmpDir, "packer.vmware.tpl")
 
-	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
-	if !strings.Contains(template.PackerTpl, "packer.json.tpl") {
-		t.Errorf("The main packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	template, err := NewPackerTemplateWithOverrides(tmpDir, "windows2012r2")
+	if err != nil {
+		t.Error("Error loading Packer templates with overrides", err)
 	}
-	if !strings.Contains(template.PackerTpl, "packer.json.tpl.vbox") {
-		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	if !strings.Contains(template.PackerTpl, "packer.tpl") {
+		t.Errorf("The main packer.tpl wasn't properly read in, got: %s", template.PackerTpl)
 	}
-	if !strings.Contains(template.PackerTpl, "packer.json.tpl.vmware") {
-		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	if !strings.Contains(template.PackerTpl, "packer.vbox.tpl") {
+		t.Errorf("The packer.vbox.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	}
+	if !strings.Contains(template.PackerTpl, "packer.vmware.tpl") {
+		t.Errorf("The packer.vmware.tpl wasn't properly read in, got: %s", template.PackerTpl)
 	}
 }
 

--- a/renderer/packer_template_test.go
+++ b/renderer/packer_template_test.go
@@ -1,0 +1,37 @@
+package renderer
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestCanLoadTemplates(t *testing.T) {
+	// create temporary directory to store all our testNewPackerTemplate() files
+	tmpDir, err := ioutil.TempDir("", "inductor")
+	if err != nil {
+		t.Error("Couldn't create test temp dir: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// stub out the vagrant, packer, and autounattend files
+	packerTplPath := path.Join(tmpDir, "packer.json.tpl")
+	autounattendTplPath := path.Join(tmpDir, "Autounattend.xml.tpl")
+	vagrantTplPath := path.Join(tmpDir, "Vagrantfile.tpl")
+
+	ioutil.WriteFile(packerTplPath, []byte("packer.json contents"), 0644)
+	ioutil.WriteFile(autounattendTplPath, []byte("Autounattend.xml contents"), 0644)
+	ioutil.WriteFile(vagrantTplPath, []byte("Vagrantfile contents"), 0644)
+
+	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
+	if template.PackerTpl != "packer.json contents" {
+		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	}
+	if template.AutounattendTpl != "Autounattend.xml contents" {
+		t.Errorf("The Autounattend.xml.tpl wasn't properly read in, got: %s", template.AutounattendTpl)
+	}
+	if template.VagrantfileTpl != "Vagrantfile contents" {
+		t.Errorf("The Vagrantfile.tpl wasn't properly read in, got: %s", template.VagrantfileTpl)
+	}
+}

--- a/renderer/packer_template_test.go
+++ b/renderer/packer_template_test.go
@@ -60,6 +60,33 @@ func TestCanLoadAutounattendMultiTemplates(t *testing.T) {
 	}
 }
 
+func TestCanLoadPackerJSONMultiTemplates(t *testing.T) {
+	// create temporary directory to store all our testNewPackerTemplate() files
+	tmpDir, err := ioutil.TempDir("", "inductor")
+	if err != nil {
+		t.Error("Couldn't create test temp dir: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// stub out the vagrant, packer, and autounattend files
+	vagrantTplPath := createTemplateFile(tmpDir, "Vagrantfile.tpl")
+	autounattendTplPath := createTemplateFile(tmpDir, "Autounattend.xml.tpl")
+	packerTplPath := createTemplateFile(tmpDir, "packer.json.tpl")
+	createTemplateFile(tmpDir, "packer.json.tpl.vbox")
+	createTemplateFile(tmpDir, "packer.json.tpl.vmware")
+
+	template := NewPackerTemplateWithOverrides(packerTplPath, autounattendTplPath, vagrantTplPath)
+	if !strings.Contains(template.PackerTpl, "packer.json.tpl") {
+		t.Errorf("The main packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	}
+	if !strings.Contains(template.PackerTpl, "packer.json.tpl.vbox") {
+		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	}
+	if !strings.Contains(template.PackerTpl, "packer.json.tpl.vmware") {
+		t.Errorf("The packer.json.tpl wasn't properly read in, got: %s", template.PackerTpl)
+	}
+}
+
 func createTemplateFile(tmpDir string, filename string) string {
 	tplPath := path.Join(tmpDir, filename)
 	ioutil.WriteFile(tplPath, []byte(filename), 0644)

--- a/renderer/template_lister.go
+++ b/renderer/template_lister.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -48,6 +49,21 @@ func FilterFilesToRender(files []string, osName string) []string {
 
 // ListFiles returns all files in the current working directory that start with
 // the specific base file name.
-func ListFiles(baseDir string, filenameBase string) ([]string, error) {
-	return filepath.Glob(filepath.Join(baseDir, filenameBase) + "*")
+func ListFiles(baseDir string, filenameBase string) []string {
+	var files []string
+	entries, _ := filepath.Glob(filepath.Join(baseDir, filenameBase) + "*")
+	for _, e := range entries {
+		if isFile(e) {
+			files = append(files, e)
+		}
+	}
+	return files
+}
+
+func isFile(path string) bool {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !fileInfo.IsDir()
 }

--- a/renderer/template_lister.go
+++ b/renderer/template_lister.go
@@ -1,0 +1,40 @@
+package renderer
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// FilterFilesToRender filters the list of files that should be rendered
+// according to inductor rules for template precedence.
+func FilterFilesToRender(files []string, osName string) []string {
+	fileMap := make(map[string]string)
+	for _, f := range files {
+		// get the filename without the OS name (if any)
+		filename := filepath.Base(f)
+		key := strings.Replace(filename, "-"+osName, "", 1)
+		fmt.Println(key)
+
+		// add an entry, but ensure we keep the OS specific entries
+		// if it produced the same key but is a longer path, it must be OS specific
+		curFile, _ := fileMap[key]
+		if len(f) > len(curFile) {
+			curFile = f
+		}
+		fileMap[key] = curFile
+	}
+
+	//var distinctFiles []string
+	distinctFiles := make([]string, 0, len(fileMap))
+	for _, v := range fileMap {
+		distinctFiles = append(distinctFiles, v)
+	}
+	return distinctFiles
+}
+
+// ListFiles returns all files in the current working directory that start with
+// the specific base file name.
+func ListFiles(baseDir string, filenameBase string) ([]string, error) {
+	return filepath.Glob(filepath.Join(baseDir, filenameBase) + "*")
+}

--- a/renderer/template_lister_test.go
+++ b/renderer/template_lister_test.go
@@ -1,0 +1,83 @@
+package renderer
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestFilterFilesToRenderWithoutCollision(t *testing.T) {
+	var files = []string{
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.offlineServicing.tpl",
+		"/Users/sneal/packer-windows/Autounattend.oobeSystem.tpl",
+		"/Users/sneal/packer-windows/Autounattend.specialize.tpl",
+	}
+	filteredFiles := FilterFilesToRender(files, "windows2012r2")
+	t.Log(filteredFiles)
+	for _, expectedFile := range files {
+		if !contains(filteredFiles, expectedFile) {
+			t.Errorf("Expected the slice to contain: %s", expectedFile)
+		}
+	}
+}
+
+func TestFilterFilesToRenderWithCollision(t *testing.T) {
+	var files = []string{
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.offlineServicing.tpl",
+	}
+	var expected = []string{
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.offlineServicing.tpl",
+	}
+	filteredFiles := FilterFilesToRender(files, "windows2012r2")
+	t.Log(filteredFiles)
+	for _, expectedFile := range expected {
+		if !contains(filteredFiles, expectedFile) {
+			t.Errorf("Expected the slice to contain: %s", expectedFile)
+		}
+	}
+}
+
+func TestCanListFiles(t *testing.T) {
+	// create temporary directory to store all our testNewPackerTemplate() files
+	tmpDir, err := ioutil.TempDir("", "inductor")
+	if err != nil {
+		t.Error("Couldn't create test temp dir: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// stub out the autounattend files
+	expected := make([]string, 0, 4)
+	expected = append(expected, createTemplateFile(tmpDir, "Autounattend.tpl"))
+	expected = append(expected, createTemplateFile(tmpDir, "Autounattend.windowsPE.tpl"))
+	expected = append(expected, createTemplateFile(tmpDir, "Autounattend-windows2012r2.windowsPE.tpl"))
+	createTemplateFile(tmpDir, "packer-windows2012r2.windowsPE.tpl")
+
+	files, err := ListFiles(tmpDir, "Autounattend")
+	if err != nil {
+		t.Error("Couldn't list glob files:", err)
+	}
+	if len(files) != 3 {
+		t.Errorf("Expected 3 files to be returned, but got %d", len(files))
+	}
+	for _, f := range expected {
+		if !contains(files, f) {
+			t.Errorf("Expected files to contain %s", f)
+		}
+	}
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/renderer/template_lister_test.go
+++ b/renderer/template_lister_test.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -77,18 +78,19 @@ func TestCanListFiles(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// stub out the autounattend files
-	expected := make([]string, 0, 4)
-	expected = append(expected, createTemplateFile(tmpDir, "Autounattend.tpl"))
-	expected = append(expected, createTemplateFile(tmpDir, "Autounattend.windowsPE.tpl"))
-	expected = append(expected, createTemplateFile(tmpDir, "Autounattend-windows2012r2.windowsPE.tpl"))
-	createTemplateFile(tmpDir, "packer-windows2012r2.windowsPE.tpl")
-
-	files, err := ListFiles(tmpDir, "Autounattend")
-	if err != nil {
-		t.Error("Couldn't list glob files:", err)
+	var expected = []string{
+		createTemplateFile(tmpDir, "packer.tpl"),
+		createTemplateFile(tmpDir, "packer.windowsPE.tpl"),
+		createTemplateFile(tmpDir, "packer-windows2012r2.windowsPE.tpl"),
 	}
-	if len(files) != 3 {
-		t.Errorf("Expected 3 files to be returned, but got %d", len(files))
+
+	// create a file and dir that shouldn't be picked up
+	createTemplateFile(tmpDir, "Autounattend-windows2012r2.windowsPE.tpl")
+	os.Mkdir(filepath.Join(tmpDir, "packer_cache"), 0644)
+
+	files := ListFiles(tmpDir, "packer")
+	if len(files) != len(expected) {
+		t.Errorf("Expected %d files to be returned, but got %d", len(expected), len(files))
 	}
 	for _, f := range expected {
 		if !contains(files, f) {

--- a/renderer/template_lister_test.go
+++ b/renderer/template_lister_test.go
@@ -15,7 +15,6 @@ func TestFilterFilesToRenderWithoutCollision(t *testing.T) {
 		"/Users/sneal/packer-windows/Autounattend.specialize.tpl",
 	}
 	filteredFiles := FilterFilesToRender(files, "windows2012r2")
-	t.Log(filteredFiles)
 	for _, expectedFile := range files {
 		if !contains(filteredFiles, expectedFile) {
 			t.Errorf("Expected the slice to contain: %s", expectedFile)
@@ -36,7 +35,32 @@ func TestFilterFilesToRenderWithCollision(t *testing.T) {
 		"/Users/sneal/packer-windows/Autounattend.offlineServicing.tpl",
 	}
 	filteredFiles := FilterFilesToRender(files, "windows2012r2")
+	for _, expectedFile := range expected {
+		if !contains(filteredFiles, expectedFile) {
+			t.Errorf("Expected the slice to contain: %s", expectedFile)
+		}
+	}
+}
+
+func TestFilterFilesToRenderWithMultipleOS(t *testing.T) {
+	var files = []string{
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.offlineServicing.tpl",
+	}
+	var expected = []string{
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.tpl",
+		"/Users/sneal/packer-windows/Autounattend-windows2012r2.windowsPE.tpl",
+		"/Users/sneal/packer-windows/Autounattend.offlineServicing.tpl",
+	}
+	filteredFiles := FilterFilesToRender(files, "windows2012r2")
 	t.Log(filteredFiles)
+	if len(filteredFiles) != len(expected) {
+		t.Errorf("Expected %d files to be returned, but got %d", len(expected), len(filteredFiles))
+	}
 	for _, expectedFile := range expected {
 		if !contains(filteredFiles, expectedFile) {
 			t.Errorf("Expected the slice to contain: %s", expectedFile)


### PR DESCRIPTION
Adds the ability to break apart templates across multiple files. The eventual goal is to allow complete customization per OS while keeping duplication at a minimum. Ultimately this is to support a Windows Nano Vbox build.
