### PR TITLE
Copy nontemplates

### DIFF
--- a/cmd/inductor/main.go
+++ b/cmd/inductor/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/joefitzgerald/inductor/configuration"
+	"github.com/joefitzgerald/inductor/cpy"
 	"github.com/joefitzgerald/inductor/renderer"
 	"github.com/joefitzgerald/inductor/tpl"
 )
@@ -85,9 +86,16 @@ func run(c *cli.Context) {
 	}
 	templates := tpl.New(cwd, opts.OSName)
 
-	// finally render all the templates to the output directory
+	// render all the templates to the output directory
 	renderer := renderer.New(opts, outDir)
 	err = renderer.Render(templates)
+	if err != nil {
+		die(err)
+	}
+
+	// copy over any non-templates to the output directory
+	copier := cpy.New()
+	err = copier.Copy(cwd, outDir)
 	if err != nil {
 		die(err)
 	}

--- a/cpy/copier.go
+++ b/cpy/copier.go
@@ -1,0 +1,7 @@
+package cpy
+
+// Copier will recursively copy all the file from the source directory
+// to the given output directory
+type Copier interface {
+	Copy(srcDir, outDir string) error
+}

--- a/cpy/cpy_suite_test.go
+++ b/cpy/cpy_suite_test.go
@@ -1,0 +1,13 @@
+package cpy_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCpy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cpy Suite")
+}

--- a/cpy/cpy_test.go
+++ b/cpy/cpy_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Cpy", func() {
 	)
 
 	BeforeEach(func() {
-		srcDir, err = ioutil.TempDir("", "inductor-src")
+		srcDir, err = ioutil.TempDir("", "inductor")
 		Expect(err).NotTo(HaveOccurred())
 		createFile(srcDir, "README.md")
 		createFile(srcDir, "Vagrantfile")
@@ -32,14 +32,12 @@ var _ = Describe("Cpy", func() {
 		createFile(srcDir, "scripts/nano/SetupComplete.cmd")
 		createFile(srcDir, ".git/blah")
 		createFile(srcDir, ".gitignore")
-		outDir, err = ioutil.TempDir("", "inductor-out")
-		Expect(err).NotTo(HaveOccurred())
+		outDir = filepath.Join(srcDir, "out")
 		copier = cpy.New()
 		err = copier.Copy(srcDir, outDir)
 	})
 	AfterEach(func() {
 		os.RemoveAll(srcDir)
-		os.RemoveAll(outDir)
 	})
 
 	Describe("Copy recursive", func() {
@@ -70,6 +68,10 @@ var _ = Describe("Cpy", func() {
 		It("should not copy hidden files", func() {
 			path := filepath.Join(outDir, ".gitignore")
 			Expect(path).ToNot(BeARegularFile())
+		})
+		It("should not copy out dir to out dir", func() {
+			path := filepath.Join(outDir, "out")
+			Expect(path).ToNot(BeADirectory())
 		})
 	})
 })

--- a/cpy/cpy_test.go
+++ b/cpy/cpy_test.go
@@ -30,6 +30,8 @@ var _ = Describe("Cpy", func() {
 		createFile(srcDir, "scripts/winrm.ps1")
 		createFile(srcDir, "scripts/windows-updates.ps1")
 		createFile(srcDir, "scripts/nano/SetupComplete.cmd")
+		createFile(srcDir, ".git/blah")
+		createFile(srcDir, ".gitignore")
 		outDir, err = ioutil.TempDir("", "inductor-out")
 		Expect(err).NotTo(HaveOccurred())
 		copier = cpy.New()
@@ -60,6 +62,14 @@ var _ = Describe("Cpy", func() {
 			Expect(filepath.Join(outDir, "scripts/winrm.ps1")).To(BeARegularFile())
 			Expect(filepath.Join(outDir, "scripts/windows-updates.ps1")).To(BeARegularFile())
 			Expect(filepath.Join(outDir, "scripts/nano/SetupComplete.cmd")).To(BeARegularFile())
+		})
+		It("should not copy hidden dirs", func() {
+			path := filepath.Join(outDir, ".git")
+			Expect(path).ToNot(BeADirectory())
+		})
+		It("should not copy hidden files", func() {
+			path := filepath.Join(outDir, ".gitignore")
+			Expect(path).ToNot(BeARegularFile())
 		})
 	})
 })

--- a/cpy/cpy_test.go
+++ b/cpy/cpy_test.go
@@ -1,0 +1,77 @@
+package cpy_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/joefitzgerald/inductor/cpy"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cpy", func() {
+	var (
+		err    error
+		copier cpy.Copier
+		outDir string
+		srcDir string
+	)
+
+	BeforeEach(func() {
+		srcDir, err = ioutil.TempDir("", "inductor-src")
+		Expect(err).NotTo(HaveOccurred())
+		createFile(srcDir, "README.md")
+		createFile(srcDir, "Vagrantfile")
+		createFile(srcDir, "Autounattend.xml.template")
+		createFile(srcDir, "Autounattend.xml.oobe.partial")
+		createFile(srcDir, "scripts/winrm.ps1")
+		createFile(srcDir, "scripts/windows-updates.ps1")
+		createFile(srcDir, "scripts/nano/SetupComplete.cmd")
+		outDir, err = ioutil.TempDir("", "inductor-out")
+		Expect(err).NotTo(HaveOccurred())
+		copier = cpy.New()
+		err = copier.Copy(srcDir, outDir)
+	})
+	AfterEach(func() {
+		os.RemoveAll(srcDir)
+		os.RemoveAll(outDir)
+	})
+
+	Describe("Copy recursive", func() {
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should ignore .template files", func() {
+			path := filepath.Join(outDir, "Autounattend.xml.template")
+			Expect(path).ToNot(BeARegularFile())
+		})
+		It("should ignore .partial files", func() {
+			path := filepath.Join(outDir, "Autounattend.xml.partial")
+			Expect(path).ToNot(BeARegularFile())
+		})
+		It("should copy regular files in src dir", func() {
+			Expect(filepath.Join(outDir, "README.md")).To(BeARegularFile())
+			Expect(filepath.Join(outDir, "Vagrantfile")).To(BeARegularFile())
+		})
+		It("should recursively copy files in sub dirs", func() {
+			Expect(filepath.Join(outDir, "scripts/winrm.ps1")).To(BeARegularFile())
+			Expect(filepath.Join(outDir, "scripts/windows-updates.ps1")).To(BeARegularFile())
+			Expect(filepath.Join(outDir, "scripts/nano/SetupComplete.cmd")).To(BeARegularFile())
+		})
+	})
+})
+
+func createFile(baseDir, path string) {
+	fullPath := filepath.Join(baseDir, path)
+	fileName := filepath.Base(fullPath)
+	fullDir := strings.TrimSuffix(fullPath, fileName)
+	os.MkdirAll(fullDir, 0744)
+	err := ioutil.WriteFile(fullPath, []byte(fileName), 0644)
+	if err != nil {
+		panic(err)
+	}
+	Expect(fullPath).To(BeARegularFile())
+}

--- a/cpy/file_copier.go
+++ b/cpy/file_copier.go
@@ -53,8 +53,8 @@ func (cp *fileCopier) initCopyDirs(srcDir, outDir string) error {
 
 func (cp *fileCopier) walkFile(sf string, sfi os.FileInfo, err error) error {
 	if sfi.IsDir() {
-		if strings.HasPrefix(sfi.Name(), ".") {
-			// don't copy hidden dirs
+		// don't copy hidden dirs or the output dir into the output dir
+		if strings.HasPrefix(sfi.Name(), ".") || sf == cp.outDir {
 			return filepath.SkipDir
 		}
 		return nil

--- a/cpy/file_copier.go
+++ b/cpy/file_copier.go
@@ -1,0 +1,104 @@
+package cpy
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type fileCopier struct {
+	srcDir string
+	outDir string
+}
+
+// New create a new cpy instance
+func New() Copier {
+	return &fileCopier{}
+}
+
+func (cp *fileCopier) Copy(srcDir, outDir string) error {
+	if err := cp.initCopyDirs(srcDir, outDir); err != nil {
+		return err
+	}
+	return filepath.Walk(srcDir, cp.walkFile)
+}
+
+func (cp *fileCopier) initCopyDirs(srcDir, outDir string) error {
+	sfi, err := os.Stat(srcDir)
+	if err != nil {
+		return err
+	}
+	if !sfi.IsDir() {
+		return errors.New("Expected Copy source to be a directory")
+	}
+
+	tfi, err := os.Stat(outDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			os.MkdirAll(outDir, 0777)
+		} else {
+			return err
+		}
+	} else {
+		if !tfi.IsDir() {
+			return errors.New("Expected Copy destination to be a directory")
+		}
+	}
+	cp.srcDir = srcDir
+	cp.outDir = outDir
+	return nil
+}
+
+func (cp *fileCopier) walkFile(sf string, sfi os.FileInfo, err error) error {
+	// don't directly do anything with subdirs template files
+	if sfi.IsDir() || filepath.Ext(sf) == ".template" || filepath.Ext(sf) == ".partial" {
+		return nil
+	}
+
+	// we have a file, calculate its relative destination location
+	rel := strings.TrimPrefix(sf, cp.srcDir)
+	df := filepath.Join(cp.outDir, rel)
+	dir := filepath.Dir(df)
+
+	if err = cp.mkdir(dir); err != nil {
+		return err
+	}
+	if err = cp.copyFile(sf, df); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cp *fileCopier) mkdir(dir string) error {
+	return os.MkdirAll(dir, 0777)
+}
+
+func (cp *fileCopier) copyFile(source, target string) (err error) {
+	//fmt.Println(fmt.Sprintf("%s => %s", source, target))
+	sf, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := sf.Close(); cerr != nil {
+			err = cerr
+		}
+	}()
+	tf, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := tf.Close(); cerr != nil {
+			err = cerr
+		}
+	}()
+	_, err = io.Copy(tf, sf)
+	if err != nil {
+		return err
+	}
+	err = tf.Sync()
+	return err
+}

--- a/cpy/file_copier.go
+++ b/cpy/file_copier.go
@@ -52,8 +52,16 @@ func (cp *fileCopier) initCopyDirs(srcDir, outDir string) error {
 }
 
 func (cp *fileCopier) walkFile(sf string, sfi os.FileInfo, err error) error {
-	// don't directly do anything with subdirs template files
-	if sfi.IsDir() || filepath.Ext(sf) == ".template" || filepath.Ext(sf) == ".partial" {
+	if sfi.IsDir() {
+		if strings.HasPrefix(sfi.Name(), ".") {
+			// don't copy hidden dirs
+			return filepath.SkipDir
+		}
+		return nil
+	}
+
+	// don't copy template files
+	if strings.HasPrefix(sfi.Name(), ".") || filepath.Ext(sf) == ".template" || filepath.Ext(sf) == ".partial" {
 		return nil
 	}
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -129,11 +129,11 @@ var listPartialTemplatesFn = listPartialTemplates
 var listPartialTemplatesOSSpecificFn = listPartialTemplatesOSSpecific
 
 func listPartialTemplates(baseDir, baseFilename string) []string {
-	return listFiles(fmt.Sprintf("%s/%s*.ptpl", baseDir, baseFilename))
+	return listFiles(fmt.Sprintf("%s/%s*.partial", baseDir, baseFilename))
 }
 
 func listPartialTemplatesOSSpecific(baseDir, baseFilename, osName string) []string {
-	return listFiles(fmt.Sprintf("%s/%s/%s*.ptpl", baseDir, osName, baseFilename))
+	return listFiles(fmt.Sprintf("%s/%s/%s*.partial", baseDir, osName, baseFilename))
 }
 
 func listFiles(globPattern string) []string {

--- a/tpl/templates.go
+++ b/tpl/templates.go
@@ -50,7 +50,7 @@ var listRootTemplatesFn = listRootTemplates
 func listRootTemplates(baseDir string) []string {
 	rootTemplates := []string{}
 	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() || filepath.Ext(path) != ".tpl" {
+		if info.IsDir() || filepath.Ext(path) != ".template" {
 			return nil
 		}
 		rootTemplates = append(rootTemplates, path)

--- a/tpl/tpl_test.go
+++ b/tpl/tpl_test.go
@@ -22,20 +22,20 @@ var _ = Describe("Tpl", func() {
 	BeforeEach(func() {
 		tmpDir, err = ioutil.TempDir("", "inductor")
 		Expect(err).NotTo(HaveOccurred())
-		createTemplateFile(tmpDir, "nano/Autounattend.xml.disks.ptpl")
-		createTemplateFile(tmpDir, "nano/packer.json.provisioners.ptpl")
-		createTemplateFile(tmpDir, "windowsxp/Autounattend.xml.tpl")
+		createTemplateFile(tmpDir, "nano/Autounattend.xml.disks.partial")
+		createTemplateFile(tmpDir, "nano/packer.json.provisioners.partial")
+		createTemplateFile(tmpDir, "windowsxp/Autounattend.xml.template")
 		createTemplateFile(tmpDir, "scripts/win-updates.ps1")
 		createTemplateFile(tmpDir, "scripts/nano/SetupComplete.cmd")
 		createTemplateFile(tmpDir, "inductor.json")
 		createTemplateFile(tmpDir, "README.md")
-		createTemplateFile(tmpDir, "Autounattend.xml.tpl")
-		createTemplateFile(tmpDir, "Autounattend.xml.oobe.ptpl")
-		createTemplateFile(tmpDir, "Autounattend.xml.disks.ptpl")
-		createTemplateFile(tmpDir, "packer.json.tpl")
-		createTemplateFile(tmpDir, "packer.json.builders.ptpl")
-		createTemplateFile(tmpDir, "packer.json.provisioners.ptpl")
-		createTemplateFile(tmpDir, "Vagrantfile.tpl")
+		createTemplateFile(tmpDir, "Autounattend.xml.template")
+		createTemplateFile(tmpDir, "Autounattend.xml.oobe.partial")
+		createTemplateFile(tmpDir, "Autounattend.xml.disks.partial")
+		createTemplateFile(tmpDir, "packer.json.template")
+		createTemplateFile(tmpDir, "packer.json.builders.partial")
+		createTemplateFile(tmpDir, "packer.json.provisioners.partial")
+		createTemplateFile(tmpDir, "Vagrantfile.template")
 	})
 	JustBeforeEach(func() {
 		templates = tpl.New(tmpDir, osName)
@@ -48,10 +48,10 @@ var _ = Describe("Tpl", func() {
 		BeforeEach(func() {
 			osName = "windows2012r2"
 		})
-		Describe("Autounattend.xml.tpl root template", func() {
+		Describe("Autounattend.xml.template root template", func() {
 			var rootTemplate tpl.Templater
 			JustBeforeEach(func() {
-				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "Autounattend.xml.tpl"))
+				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "Autounattend.xml.template"))
 			})
 			It("should be found", func() {
 				Expect(rootTemplate).ToNot(BeNil())
@@ -59,21 +59,21 @@ var _ = Describe("Tpl", func() {
 			It("should have 2 partial templates", func() {
 				Expect(rootTemplate.ListTemplates()).To(HaveLen(2))
 			})
-			It("should include Autounattend.xml.oobe.ptpl", func() {
-				path := filepath.Join(tmpDir, "Autounattend.xml.oobe.ptpl")
+			It("should include Autounattend.xml.oobe.partial", func() {
+				path := filepath.Join(tmpDir, "Autounattend.xml.oobe.partial")
 				Expect(rootTemplate.FindTemplate(path)).ToNot(BeNil())
 			})
-			It("should include Autounattend.xml.disks.ptpl", func() {
-				path := filepath.Join(tmpDir, "Autounattend.xml.disks.ptpl")
+			It("should include Autounattend.xml.disks.partial", func() {
+				path := filepath.Join(tmpDir, "Autounattend.xml.disks.partial")
 				Expect(rootTemplate.FindTemplate(path)).ToNot(BeNil())
 			})
 			It("should have template content", func() {
-				expected := `Autounattend.xml.tpl
+				expected := `Autounattend.xml.template
 {{define "disks"}}
-Autounattend.xml.disks.ptpl
+Autounattend.xml.disks.partial
 {{end}}
 {{define "oobe"}}
-Autounattend.xml.oobe.ptpl
+Autounattend.xml.oobe.partial
 {{end}}`
 				var buffer bytes.Buffer
 				Expect(rootTemplate.Content(&buffer)).NotTo(HaveOccurred())
@@ -86,10 +86,10 @@ Autounattend.xml.oobe.ptpl
 		BeforeEach(func() {
 			osName = "nano"
 		})
-		Describe("Autounattend.xml.tpl root template", func() {
+		Describe("Autounattend.xml.template root template", func() {
 			var rootTemplate tpl.Templater
 			JustBeforeEach(func() {
-				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "Autounattend.xml.tpl"))
+				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "Autounattend.xml.template"))
 			})
 			It("should be found", func() {
 				Expect(rootTemplate).ToNot(BeNil())
@@ -97,20 +97,20 @@ Autounattend.xml.oobe.ptpl
 			It("should have 2 partial templates", func() {
 				Expect(rootTemplate.ListTemplates()).To(HaveLen(2))
 			})
-			It("should include Autounattend.xml.oobe.ptpl", func() {
-				path := filepath.Join(tmpDir, "Autounattend.xml.oobe.ptpl")
+			It("should include Autounattend.xml.oobe.partial", func() {
+				path := filepath.Join(tmpDir, "Autounattend.xml.oobe.partial")
 				Expect(rootTemplate.FindTemplate(path)).ToNot(BeNil())
 			})
-			It("should include nano/Autounattend.xml.disks.ptpl", func() {
-				path := filepath.Join(tmpDir, "nano/Autounattend.xml.disks.ptpl")
+			It("should include nano/Autounattend.xml.disks.partial", func() {
+				path := filepath.Join(tmpDir, "nano/Autounattend.xml.disks.partial")
 				Expect(rootTemplate.FindTemplate(path)).ToNot(BeNil())
 			})
 		})
 
-		Describe("packer.json.tpl root template", func() {
+		Describe("packer.json.template root template", func() {
 			var rootTemplate tpl.Templater
 			JustBeforeEach(func() {
-				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "packer.json.tpl"))
+				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "packer.json.template"))
 			})
 			It("should be found", func() {
 				Expect(rootTemplate).ToNot(BeNil())
@@ -118,20 +118,20 @@ Autounattend.xml.oobe.ptpl
 			It("should have 2 partial templates", func() {
 				Expect(rootTemplate.ListTemplates()).To(HaveLen(2))
 			})
-			It("should include packer.json.builders.ptpl", func() {
-				path := filepath.Join(tmpDir, "packer.json.builders.ptpl")
+			It("should include packer.json.builders.partial", func() {
+				path := filepath.Join(tmpDir, "packer.json.builders.partial")
 				Expect(rootTemplate.FindTemplate(path)).ToNot(BeNil())
 			})
-			It("should include nano/packer.json.provisioners.ptpl", func() {
-				path := filepath.Join(tmpDir, "nano/packer.json.provisioners.ptpl")
+			It("should include nano/packer.json.provisioners.partial", func() {
+				path := filepath.Join(tmpDir, "nano/packer.json.provisioners.partial")
 				Expect(rootTemplate.FindTemplate(path)).ToNot(BeNil())
 			})
 		})
 
-		Describe("Vagrantfile.tpl root template", func() {
+		Describe("Vagrantfile.template root template", func() {
 			var rootTemplate tpl.Templater
 			JustBeforeEach(func() {
-				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "Vagrantfile.tpl"))
+				rootTemplate = templates.FindTemplate(filepath.Join(tmpDir, "Vagrantfile.template"))
 			})
 			It("should be found", func() {
 				Expect(rootTemplate).ToNot(BeNil())


### PR DESCRIPTION
Copies all non-templates to the output directory.
- Supports checking all compiled output into source control
- Can compile into the source directory (old behavior)
- Template file extensions changed to .template and .partial
